### PR TITLE
Add extra annotation actions and properties

### DIFF
--- a/modules/annotations/EVENTS.md
+++ b/modules/annotations/EVENTS.md
@@ -33,6 +33,11 @@ It can be called several times during one edit action.
 ##### annotation-edit | ``{object: fabric.Object}``
 This event is fired when user performs direct annotation editing.
 
+##### annotation-edit-prop | ``{object: fabric.Object, property: string}``
+This event is fired if any extra properties of an annotation change.
+These are properties that don't change the appearance of an annotation and can be stored in a separate database/storage.
+examples: `private`, `locked`
+
 ##### preset-delete | ``{preset: OSDAnnotations.Preset}``
 
 ##### preset-create | ``{preset: OSDAnnotations.Preset}``

--- a/modules/annotations/annotations.js
+++ b/modules/annotations/annotations.js
@@ -279,6 +279,7 @@ window.OSDAnnotations = class extends XOpatModuleSingleton {
 		//prevent immediate serialization as we feed it to a merge
 		options.serialize = false;
 		let output = await OSDAnnotations.Convertor.encodePartial(options, this, withAnnotations, withPresets);
+		output.objects = output.objects.filter(o => !o.private);
 		this.raiseEvent('export-partial', {
 			options: options,
 			data: output
@@ -858,6 +859,16 @@ window.OSDAnnotations = class extends XOpatModuleSingleton {
 
 		if (_raise) this.raiseEvent('annotation-create', {object: annotation});
 		this.canvas.renderAll();
+	}
+
+	/**
+	 * Change annotation's `private` property
+	 * @param {fabric.Object} annotation Any annotation
+	 * @param {boolean} value New value
+	 */
+	changeAnnotationPrivateProperty(annotation, value) {
+		annotation.private = value;
+		this.raiseEvent('annotation-edit-prop', {object: annotation, property: 'private'});
 	}
 
 	/**

--- a/modules/annotations/objects.js
+++ b/modules/annotations/objects.js
@@ -79,6 +79,7 @@ OSDAnnotations.AnnotationObjectFactory = class {
         "author",
         "created",
         "id",
+        "private",
     ];
 
     /**

--- a/plugins/annotations/annotationsGUI.js
+++ b/plugins/annotations/annotationsGUI.js
@@ -56,6 +56,8 @@ class AnnotationsGUI extends XOpatPlugin {
 			_this.context.setAnnotationCommonVisualProperty('originalStrokeWidth', Number.parseFloat($(this).val()));
 		});
 		this.preview = new AnnotationsGUI.Previewer("preview", this);
+
+		this._copiedAnnotation = null
 	}
 
 	async setupFromParams() {
@@ -442,6 +444,67 @@ onchange: this.THIS + ".setOption('importReplace', !!this.checked)", default: th
 					},
 				});
 			});
+
+			if (active) {
+				const props = this._getAnnotationProps(active);
+				const handlerMarkPrivate = this._clickAnnotationMarkPrivate.bind(this, active);
+
+				actions.push({
+					title: "Modify annotation:",
+				})
+				actions.push({
+					title: props.private ? "Unmark as private" : "Mark as private",
+					icon: props.private ? "visibility" : "visibility_lock",
+					action: () => {
+						handlerMarkPrivate();
+					}
+				})
+			}
+
+			actions.push({
+				title: "Actions:",
+			});
+
+			const handlerCopy = this._copyAnnotation.bind(this, active);
+			actions.push({
+				title: "Copy",
+				icon: "content_copy",
+				containerCss: !active && 'opacity-50',
+				action: () => {
+					if (active) handlerCopy();
+				}
+			})
+
+			const handlerCut = this._cutAnnotation.bind(this, active);
+			actions.push({
+				title: "Cut",
+				icon: "content_cut",
+				containerCss: !active && 'opacity-50',
+				action: () => {
+					if (active) handlerCut();
+				}
+			})
+
+			const canPaste = this._canPasteAnnotation(e);
+			const handlerPaste = this._pasteAnnotation.bind(this, e);
+			actions.push({
+				title: "Paste",
+				icon: "content_paste",
+				containerCss: !canPaste && 'opacity-50',
+				action: () => {
+					if (canPaste) handlerPaste();
+				}
+			})
+
+			const handlerDelete = this._deleteAnnotation.bind(this, active);
+			actions.push({
+				title: "Delete",
+				icon: "delete",
+				containerCss: !active && 'opacity-50',
+				action: () => {
+					if (active) handlerDelete();
+				}
+			})
 
 			USER_INTERFACE.DropDown.open(e.originalEvent, actions);
 		});
@@ -1186,6 +1249,71 @@ class="btn m-2">Set for left click </button></div>`
 		return false;
 	}
 
+	_getMousePosition(e, checkBounds = true) {
+		const image = VIEWER.scalebar.getReferencedTiledImage() || VIEWER.world.getItemAt(0);
+		if (!image) return {x: 0, y: 0};
+		const screen = new OpenSeadragon.Point(e.originalEvent.x, e.originalEvent.y);
+
+		const {x, y} = image.windowToImageCoordinates(screen);
+		const {x: maxX, y: maxY} = image.getContentSize();
+
+		if (
+			checkBounds && (
+				x <= 0 ||
+				y <= 0 ||
+				x >= maxX ||
+				y >= maxY
+			)
+		) {
+			return false;
+		} else {
+			return {x, y};
+		}
+	}
+
+	_copyAnnotation(annotation) {
+		this._copiedAnnotation = annotation;
+	}
+
+	_cutAnnotation(annotation) {
+		this._copiedAnnotation = annotation;
+		this._deleteAnnotation(annotation);
+	}
+
+	_deleteAnnotation(annotation) {
+		this.context.deleteObject(annotation);
+		this.context.canvas.requestRenderAll();
+	}
+
+	_canPasteAnnotation(e, getMouseValue = false) {
+		if (!this._copiedAnnotation) return null;
+		const mousePos = this._getMousePosition(e);
+		if (getMouseValue) return mousePos;
+		else return !!mousePos;
+	}
+
+	_pasteAnnotation(e) {
+		const mousePos = this._canPasteAnnotation(e, true);
+		if (!mousePos) {
+			if (mousePos === false) Dialogs.show('Cannot paste annotation out of bounds', 5000, Dialogs.MSG_WARN);
+			return;
+		}
+
+		const annotation = this._copiedAnnotation;
+		const factory = annotation._factory();
+		const res = factory.copy(
+			annotation,
+			{
+				left: mousePos.x,
+				top: mousePos.y,
+				width: annotation.width,
+				height: annotation.height,
+			}
+		)
+		this.context.addAnnotation(res);
+		this.context.canvas.requestRenderAll();
+	}
+
 	_clickAnnotationChangePreset(annotation) {
 		if (this._presetSelection === undefined) {
 			Dialogs.show('You must click on a preset to be selected first.', 5000, Dialogs.MSG_WARN);
@@ -1198,6 +1326,20 @@ class="btn m-2">Set for left click </button></div>`
 			_this.context.canvas.requestRenderAll();
 		}, 150);
 		return false;
+	}
+
+	_clickAnnotationMarkPrivate(annotation) {
+		const _this = this;
+		const newValue = !this._getAnnotationProps(annotation).private;
+
+		_this.context.changeAnnotationPrivateProperty(annotation, newValue);
+		Dialogs.show(`Annotation is now ${newValue ? 'private' : 'public'}.`, 2000, Dialogs.MSG_INFO);
+	}
+
+	_getAnnotationProps(annotation) {
+		return {
+			private: annotation.private
+		};
 	}
 
 	createNewPreset(buttonNode, isLeftClick) {

--- a/src/libs/tailwind.min.css
+++ b/src/libs/tailwind.min.css
@@ -2559,6 +2559,26 @@ details.collapse summary::-webkit-details-marker {
   font-weight: 500;
 }
 
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
+.opacity-25 {
+  opacity: 0.25;
+}
+
+.opacity-50 {
+  opacity: 0.5;
+}
+
+.opacity-75 {
+  opacity: 0.75;
+}
+
 .outline {
   outline-style: solid;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,11 @@ module.exports = {
   //     pattern: /./, // the "." means "everything"
   //   },
   // ],
+  safelist: [
+    {
+      pattern: /^opacity-(0|25|50|75|100)/,
+    },
+  ],
   plugins: [
     require("@catppuccin/tailwindcss"),
     require("daisyui")


### PR DESCRIPTION
- Added extra annotation properties
  - event: `annotation-edit-prop` [docs](https://github.com/ShadowAya/xopat/blob/f4df1df94ff5c17efc902d507dfa4f56e7f3fbde/modules/annotations/EVENTS.md?plain=1#L36)
  - implemented `private` property for now, which excludes annotation from export
- Added copy, cut, paste, delete actions to context menu of an annotation
- Added mark as private to context menu of an annotation
- Added plain opacity classes to Tailwind safelist