### PR TITLE
Before-canvas-reload event

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1061,25 +1061,13 @@ function initXopat(PLUGINS, MODULES, ENV, POST_DATA, PLUGINS_FOLDER, MODULES_FOL
      * @param background
      * @param visualizations
      */
-    APPLICATION_CONTEXT.openViewerWith = async function (
+    APPLICATION_CONTEXT.openViewerWith = function (
         data,
         background,
         visualizations = [],
     ) {
         USER_INTERFACE.Loading.show(true);
         VIEWER.close();
-
-        const config = APPLICATION_CONTEXT._dangerouslyAccessConfig();
-        config.data = data;
-        config.background = background;
-        config.visualizations = visualizations;
-
-        /**
-         * Allows plugins to modify the config before rendering
-         * @memberOf VIEWER
-         * @event before-open-with
-         */
-        await VIEWER.tools.raiseAwaitEvent(VIEWER, 'before-open-with', { data, background, visualizations });
 
         const isSecureMode = APPLICATION_CONTEXT.secure;
         let renderingWithWebGL = visualizations?.length > 0;
@@ -1097,16 +1085,19 @@ function initXopat(PLUGINS, MODULES, ENV, POST_DATA, PLUGINS_FOLDER, MODULES_FOL
                 renderingWithWebGL = false;
             }
         }
-
         loadTooLongTimeout = setTimeout(() => Dialogs.show($.t('error.slide.pending'), 15000, Dialogs.MSG_WARN), 8000);
-        if (reopenCounter > 0) {
-            APPLICATION_CONTEXT.disableVisualization();
-        } else {
+
+        const config = APPLICATION_CONTEXT._dangerouslyAccessConfig();
+        config.data = data;
+        config.background = background;
+        config.visualizations = visualizations;
+
+        if (reopenCounter >= 0) {
             /**
-             * Fired before visualization is initialized and loaded.
-             * @memberOf VIEWER
-             * @event before-canvas-reload
-             */
+            * Fired before visualization is initialized and loaded.
+            * @memberOf VIEWER
+            * @event before-canvas-reload
+            */
             VIEWER.raiseEvent('before-canvas-reload');
         }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1093,13 +1093,14 @@ function initXopat(PLUGINS, MODULES, ENV, POST_DATA, PLUGINS_FOLDER, MODULES_FOL
         config.visualizations = visualizations;
 
         if (reopenCounter >= 0) {
-            /**
-             * Fired before visualization is initialized and loaded.
-             * @memberOf VIEWER
-             * @event before-canvas-reload
-             */
-            VIEWER.raiseEvent('before-canvas-reload');
+            APPLICATION_CONTEXT.disableVisualization();
         }
+        /**
+         * Fired before visualization is initialized and loaded.
+         * @memberOf VIEWER
+         * @event before-canvas-reload
+         */
+        VIEWER.raiseEvent('before-canvas-reload');
 
         const toOpen = [];
         const opacity = Number.parseFloat($("global-opacity").val()) || 1;

--- a/src/app.js
+++ b/src/app.js
@@ -1094,10 +1094,10 @@ function initXopat(PLUGINS, MODULES, ENV, POST_DATA, PLUGINS_FOLDER, MODULES_FOL
 
         if (reopenCounter >= 0) {
             /**
-            * Fired before visualization is initialized and loaded.
-            * @memberOf VIEWER
-            * @event before-canvas-reload
-            */
+             * Fired before visualization is initialized and loaded.
+             * @memberOf VIEWER
+             * @event before-canvas-reload
+             */
             VIEWER.raiseEvent('before-canvas-reload');
         }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1092,7 +1092,7 @@ function initXopat(PLUGINS, MODULES, ENV, POST_DATA, PLUGINS_FOLDER, MODULES_FOL
         config.background = background;
         config.visualizations = visualizations;
 
-        if (reopenCounter >= 0) {
+        if (reopenCounter > 0) {
             APPLICATION_CONTEXT.disableVisualization();
         }
         /**

--- a/src/app.js
+++ b/src/app.js
@@ -1061,13 +1061,25 @@ function initXopat(PLUGINS, MODULES, ENV, POST_DATA, PLUGINS_FOLDER, MODULES_FOL
      * @param background
      * @param visualizations
      */
-    APPLICATION_CONTEXT.openViewerWith = function (
+    APPLICATION_CONTEXT.openViewerWith = async function (
         data,
         background,
         visualizations = [],
     ) {
         USER_INTERFACE.Loading.show(true);
         VIEWER.close();
+
+        const config = APPLICATION_CONTEXT._dangerouslyAccessConfig();
+        config.data = data;
+        config.background = background;
+        config.visualizations = visualizations;
+
+        /**
+         * Allows plugins to modify the config before rendering
+         * @memberOf VIEWER
+         * @event before-open-with
+         */
+        await VIEWER.tools.raiseAwaitEvent(VIEWER, 'before-open-with', { data, background, visualizations });
 
         const isSecureMode = APPLICATION_CONTEXT.secure;
         let renderingWithWebGL = visualizations?.length > 0;
@@ -1085,13 +1097,8 @@ function initXopat(PLUGINS, MODULES, ENV, POST_DATA, PLUGINS_FOLDER, MODULES_FOL
                 renderingWithWebGL = false;
             }
         }
+
         loadTooLongTimeout = setTimeout(() => Dialogs.show($.t('error.slide.pending'), 15000, Dialogs.MSG_WARN), 8000);
-
-        const config = APPLICATION_CONTEXT._dangerouslyAccessConfig();
-        config.data = data;
-        config.background = background;
-        config.visualizations = visualizations;
-
         if (reopenCounter > 0) {
             APPLICATION_CONTEXT.disableVisualization();
         } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made viewer reopen/reload behavior more consistent: visualization disable logic now applies under broader conditions, and the reload-related event is always dispatched to reduce intermittent display issues when reopening the viewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->