### PR TITLE
fix: production minification file serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ Thumbs.db
 #builds and binaries
 *.min.js
 *.min.js.map
+*.min.mjs
+*.min.mjs.map
 /openseadragon/
 /openseadragon-new/
 /node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 const BuildLogic = require("./server/utils/mixins/build-logic");
+const { classifyIncludeFoldable, classifyIncludeKind } = require("./server/templates/javascript/utils");
 
 module.exports = function(grunt) {
     // import utils first to initialize them
@@ -107,29 +108,71 @@ module.exports = function(grunt) {
     });
 
     // DYNAMIC MINIFICATION CONFIG
+    // Build the uglify file-map: one `index.min.js` per NON-workspace item,
+    // concatenating only the *foldable* includes (plain local classic .js).
+    // Workspace items already ship a minified bundle (index.workspace.min.js,
+    // copied during workspaceBuild) so they are skipped here — re-uglifying an
+    // already-minified bundle is wasteful and would double-wrap it. `.mjs`,
+    // remote, already-`.min.js` and object-form (SRI / `bundle:false` worker)
+    // includes are excluded by the shared classifyIncludeFoldable predicate and
+    // keep loading as their own files. See server/templates/javascript/utils.js.
     grunt.registerTask('prepMinify', function() {
+        const collect = (target, prefix) => (acc, item, folder) => {
+            const isWorkspace = item["__workspace_item_entry__"]
+                || (Array.isArray(item.includes) && item.includes[0] === "index.workspace.js");
+            if (isWorkspace) return;
+            const foldable = (item.includes || [])
+                .filter(classifyIncludeFoldable)
+                .map(i => `${item.directory}/${i}`);
+            if (foldable.length) {
+                target[`${prefix}/${folder}/index.min.js`] = foldable;
+            }
+        };
+
         const moduleFiles = {};
         const pluginFiles = {};
-
-        grunt.util.reduceModules((acc, mod, folder) => {
-            moduleFiles[`modules/${folder}/index.min.js`] = mod.includes
-                .filter(i => typeof i === "string" && !i.endsWith(".min.js"))
-                .map(i => `${mod.directory}/${i}`);
-        }, {});
-
-        grunt.util.reducePlugins((acc, plug, folder) => {
-            pluginFiles[`plugins/${folder}/index.min.js`] = plug.includes
-                .filter(i => typeof i === "string" && !i.endsWith(".min.js"))
-                .map(i => `${plug.directory}/${i}`);
-        }, {});
+        grunt.util.reduceModules(collect(moduleFiles, "modules"), {});
+        grunt.util.reducePlugins(collect(pluginFiles, "plugins"), {});
 
         grunt.config.set('uglify.modules.files', moduleFiles);
         grunt.config.set('uglify.plugins.files', pluginFiles);
     });
 
-    grunt.registerTask('minify', ['workspaceBuild', 'buildUI', 'prepMinify', 'uglify']);
-    grunt.registerTask('default', ['minify']);
+    // Bundle each NON-workspace item's `.mjs` includes into one minified ESM
+    // file (index.min.mjs). Classic `.js` includes are handled by prepMinify +
+    // uglify (index.min.js); this covers the module half so `.mjs`-only plugins
+    // are minified in production too. Workspace items are skipped (they build
+    // their own index.workspace.min.js).
+    grunt.registerTask('bundleModules', 'Bundle .mjs includes into minified ESM per item', async function() {
+        const done = this.async();
+        const logger = {
+            log: (m) => grunt.log.writeln(m),
+            warn: (m) => grunt.log.warn(m),
+            error: (m) => grunt.log.error(m),
+        };
+        const run = async (acc, item) => {
+            const isWorkspace = item["__workspace_item_entry__"]
+                || (Array.isArray(item.includes) && item.includes[0] === "index.workspace.js");
+            if (isWorkspace) return;
+            const mjs = (item.includes || []).filter(e => classifyIncludeKind(e) === "module");
+            if (!mjs.length) return;
+            try {
+                await BuildLogic.buildItemModuleBundle(item.directory, mjs, logger);
+            } catch (e) {
+                grunt.log.warn(`bundleModules ${item.directory}: ${e && e.message || e}`);
+            }
+        };
+        await grunt.util.reduceModules(run, []);
+        await grunt.util.reducePlugins(run, []);
+        done();
+    });
 
+    // Production build: also compiles the core (per-file dist AND the single
+    // minified src/dist/xopat-core.min.js bundle) so `client.production` has a
+    // complete set of min artifacts to serve. `buildCore` was previously absent
+    // here, so `minify` never produced the core dist at all. `bundleModules`
+    // produces the per-item ESM bundles (index.min.mjs) for `.mjs` includes.
+    grunt.registerTask('minify', ['workspaceBuild', 'buildUI', 'buildCore', 'prepMinify', 'uglify', 'bundleModules']);
     grunt.registerTask('default', ['minify']);
     grunt.registerTask('all', ['minify']);
 

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -52,6 +52,11 @@ COPY --chown=node:node . /app
 
 USER node
 
-RUN npm ci && npm run build
+# `minify` is a superset of `build` (workspaceBuild + buildUI + buildCore) plus
+# prepMinify + uglify + bundleModules, so the image ships the production min
+# artifacts (index.min.js / index.min.mjs / index.workspace.min.js /
+# src/dist/xopat-core.min.js / ui/index.min.js). They are only *served* when the
+# deployment sets client.production: true, so this is safe for dev images too.
+RUN npm ci && npm run minify
 
 ENTRYPOINT ["/usr/bin/tini", "--", "npm", "run", "s-node"]

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -44,7 +44,13 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh \
 FROM viewer-build-deps AS viewer-build
 ENV XO_REPO_ROOT=/tmp/xopat
 COPY . /tmp/xopat
-RUN cd /tmp/xopat && npm ci && npm run build
+# `minify` is a superset of `build` (workspaceBuild + buildUI + buildCore) plus
+# prepMinify + uglify + bundleModules, so the produced tree carries the
+# production min artifacts (index.min.js / index.min.mjs / index.workspace.min.js
+# / src/dist/xopat-core.min.js / ui/index.min.js) that viewer-standalone copies.
+# They are only *served* when the deployment sets client.production: true, so the
+# viewer-dev image built from this stage is unaffected.
+RUN cd /tmp/xopat && npm ci && npm run minify
 
 ##################
 # VIEWER: DEV  ###

--- a/docs/site/src/components/DemoFrame/index.js
+++ b/docs/site/src/components/DemoFrame/index.js
@@ -37,6 +37,11 @@ export default function DemoFrame({
   // experimental / work in progress" warning above it. Detected after mount
   // (SSR-safe); defaults to desktop (no warning). Remove once mobile is solid.
   const [isMobile, setIsMobile] = useState(false);
+  // The embedded viewer is heavy (full xOpat app + WSI tile streams + WebGL).
+  // Track load so we can show a placeholder instead of an empty box until the
+  // iframe fires `onLoad`. Combined with `loading="lazy"` below, a demo that is
+  // scrolled off-screen doesn't boot at all until the reader reaches it.
+  const [isLoaded, setIsLoaded] = useState(false);
   useEffect(() => {
     const ua = navigator.userAgent || '';
     const mobileUA = /Mobi|Android|iPhone|iPod|IEMobile|Windows Phone/i.test(ua);
@@ -70,30 +75,84 @@ export default function DemoFrame({
 
   const heightCss = typeof height === 'number' ? `${height}px` : height;
   const zoom = scale > 0 && scale < 1;
-  const frame = zoom ? (
+
+  // Shared iframe attributes. `loading="lazy"` defers booting the viewer until
+  // it is near the viewport; `onLoad` reveals it (and hides the placeholder).
+  const iframeProps = {
+    src,
+    title: 'xOpat live demo',
+    allow: 'fullscreen',
+    loading: 'lazy',
+    onLoad: () => setIsLoaded(true),
+  };
+  const revealStyle = {
+    opacity: isLoaded ? 1 : 0,
+    transition: 'opacity 0.3s ease',
+  };
+
+  const inner = zoom ? (
     // Container clips the oversized iframe to the visible box; the iframe is
     // rendered `1/scale` larger then scaled back down from the top-left corner.
     <div style={{width: '100%', height: heightCss, overflow: 'hidden'}}>
       <iframe
-        src={src}
+        {...iframeProps}
         style={{
           width: `${100 / scale}%`,
           height: `calc(${heightCss} / ${scale})`,
           border: 0,
           transform: `scale(${scale})`,
           transformOrigin: '0 0',
+          ...revealStyle,
         }}
-        title="xOpat live demo"
-        allow="fullscreen"
       />
     </div>
   ) : (
     <iframe
-      src={src}
-      style={{width: '100%', height: heightCss, border: 0}}
-      title="xOpat live demo"
-      allow="fullscreen"
+      {...iframeProps}
+      style={{width: '100%', height: heightCss, border: 0, ...revealStyle}}
     />
+  );
+
+  const frame = (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: heightCss,
+        background: 'var(--ifm-background-surface-color)',
+        borderRadius: 'var(--ifm-global-radius)',
+        overflow: 'hidden',
+      }}>
+      {inner}
+      {!isLoaded && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: '0.75rem',
+            color: 'var(--ifm-color-emphasis-700)',
+            pointerEvents: 'none',
+          }}>
+          {/* Self-contained SMIL spinner — no extra CSS file/keyframes needed. */}
+          <svg width="40" height="40" viewBox="0 0 50 50" aria-hidden="true"
+               style={{color: 'var(--ifm-color-primary)'}}>
+            <circle cx="25" cy="25" r="20" fill="none" stroke="currentColor"
+                    strokeWidth="5" strokeLinecap="round" strokeDasharray="90 60">
+              <animateTransform attributeName="transform" type="rotate"
+                                from="0 25 25" to="360 25 25" dur="1s"
+                                repeatCount="indefinite" />
+            </circle>
+          </svg>
+          <span>Loading demo…</span>
+        </div>
+      )}
+    </div>
   );
 
   const sourceDetails = config && showSource && (

--- a/modules/README.md
+++ b/modules/README.md
@@ -35,7 +35,7 @@ Moreover, it is advised to use ENV setup (see `/env/README.md`) to override nece
 - `name` is the module name
 - `description` is a text displayed to the user to let them know what the module does: it should be short and concise
 - `author` is the module author
-- `includes` is a list of JavaScript files relative to the module folder to include
+- `includes` is a list of JavaScript files relative to the module folder to include. In production (`client.production`, built with `npm run minify`) local `.js` includes are concatenated into `index.min.js` and local `.mjs` modules are bundled into `index.min.mjs`; remote, `.min.js` and object-form includes stay separate. Mark a local `.js` that must not be bundled (e.g. a Web Worker source) with `{ "src": "x.js", "bundle": false }`. See `plugins/README.md` → *Production minification* for the full rule.
 - `requires` array of id's of required modules (libraries)
 - `enabled` is an option to allow or disallow the module to be loaded into the system, default `true`
 - `permaLoad` always loads the module within the system if set to `true`, default `false`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "i18n-audit": "grunt i18n-audit",
     "postinstall": "grunt build",
     "minify": "grunt minify",
+    "build:prod": "grunt minify",
     "test": "npx cypress run --browser chrome --e2e",
     "test-w": "cross-env ELECTRON_ENABLE_LOGGING=1 npx cypress open",
     "build-css": "npx tailwindcss -i ./src/assets/tailwind-spec.css -o ./src/libs/tailwind.min.css",

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -455,6 +455,33 @@ or an object to specify a file on the web. The object properties (almost) map to
     ]
 }
 ```` 
+
+##### Production minification (`bundle`)
+When the deployment runs with `client.production: true` (build with `npm run
+minify`), each plugin/module is served as **minified bundle(s)** instead of the
+raw include list:
+- local classic `.js` includes are concatenated + minified into `index.min.js`;
+- local `.mjs` ES modules are esbuild-bundled + minified into `index.min.mjs`
+  (served as `type="module"`, syntax preserved — e.g. `import.meta`);
+- workspace (npm-package) items ship `index.workspace.min.js`.
+
+An item with both classic and module includes gets both files. Entries that
+*cannot* be bundled are detected automatically and keep loading as their own
+files: remote `http(s)` URLs, already-`.min.js` bundles, and any object-form
+include (SRI/attributes).
+
+If a **local `.js`** file must NOT be folded into the bundle — e.g. a Web Worker
+source that only looks foldable by its `.js` suffix — mark it with
+`"bundle": false` (object form). It then always loads as its own file and is
+never concatenated:
+````json
+{
+    "includes": [
+        "app.js",
+        { "src": "my.worker.js", "bundle": false }
+    ]
+}
+````
 ## Viewer Multiplexing
 There can be multiple viewers open at once. You might need to create:
 - custom viewer-oriented menus: use ``VIEWER_MANAGER.getMenu(...)`` method to access desired menu component and add custom content

--- a/plugins/dicom/include.json
+++ b/plugins/dicom/include.json
@@ -15,8 +15,12 @@
   "requiredConfig": ["serviceUrl"],
   "includes": [
     "dist/dcmjs.js",
-    "dist/cornerstoneWADOImageLoader.bundle.min.js",
-    "dist/index.worker.bundle.min.worker.js"
+    // Minified file, do not bundle.
+    { "src": "dist/cornerstoneWADOImageLoader.bundle.min.js", "bundle": false },
+    // Web Worker source: despite the `.js` suffix it must stay a standalone
+    // file (it is loaded as a worker, not bundled). `bundle: false` keeps the
+    // production minifier from folding it into index.min.js.
+    { "src": "dist/index.worker.bundle.min.worker.js", "bundle": false }
   ],
   // Default study to open
   "defaultStudy": "1.2.826.0.1.3680043.8.498.35759453015100453210054623601138997522",

--- a/server/php/inc/core.php
+++ b/server/php/inc/core.php
@@ -253,6 +253,13 @@ if (!$client || !isset($CORE["client"][$client])) {
 }
 $CORE["client"] = $C;
 
+// Coerce the production flag to a real boolean at the client-flatten boundary,
+// so every downstream check is correct even if it arrived as a string (e.g.
+// "false" from an env var, which is truthy under !empty()).
+if (is_array($CORE["client"])) {
+    $CORE["client"]["production"] = filter_var($CORE["client"]["production"] ?? false, FILTER_VALIDATE_BOOLEAN);
+}
+
 // Version source of truth is package.json (same as the Node server, see
 // server/node/index.js readStartupVersion). config.json `version` stays null so
 // there is a single place to bump; fall back to package.json when it is unset.
@@ -375,6 +382,19 @@ function require_external() {
     print_js($CORE["js"]["external"], EXTERNAL_SOURCES);
 }
 
+/**
+ * Robust truthiness for the `production` client flag. Uses
+ * FILTER_VALIDATE_BOOLEAN so a string "false" / "0" / "" (e.g. injected from an
+ * environment variable) is correctly treated as false — unlike `!empty()`, for
+ * which any non-empty string (including "false") is truthy. Mirrors parseBool()
+ * in the Node core template.
+ */
+function xopat_is_production(): bool {
+    global $CORE;
+    if (!is_array($CORE) || !isset($CORE["client"]) || !is_array($CORE["client"])) return false;
+    return filter_var($CORE["client"]["production"] ?? false, FILTER_VALIDATE_BOOLEAN);
+}
+
 function require_core($type) {
     global $CORE;
     static $bundleEmitted = false;
@@ -383,7 +403,7 @@ function require_core($type) {
     // minified bundle (src/dist/xopat-core.min.js), emitted once on the first
     // core JS group requested; per-group CSS is preserved and `env` goes
     // per-file. Falls back to per-file dev serving when the bundle isn't built.
-    $production = !empty($CORE["client"]["production"]);
+    $production = xopat_is_production();
     if ($production && in_array($type, ["loader", "deps", "app"], true)
         && file_exists(VIEWER_SOURCES_ABS_ROOT . "dist/xopat-core.min.js")) {
         if (isset($CORE["css"]["src"][$type])) print_css_single($CORE["css"]["src"][$type], PROJECT_SOURCES);
@@ -403,7 +423,7 @@ function require_ui() {
     global $CORE;
     // In production, serve the prebuilt single UI bundle (ui/index.min.js),
     // preserving any UI CSS. Falls back to the ESM index.js otherwise.
-    if (!empty($CORE["client"]["production"]) && file_exists(ABSPATH . "ui/index.min.js")) {
+    if (xopat_is_production() && file_exists(ABSPATH . "ui/index.min.js")) {
         if (isset($CORE["css"]["ui"])) print_css($CORE["css"]["ui"], UI_SOURCES);
         $version = VERSION;
         echo "    <script src=\"" . UI_SOURCES . "index.min.js?v=$version\"></script>\n";

--- a/server/php/inc/core.php
+++ b/server/php/inc/core.php
@@ -377,12 +377,38 @@ function require_external() {
 
 function require_core($type) {
     global $CORE;
+    static $bundleEmitted = false;
+
+    // In production, serve the whole core JS (loader + deps + app groups) as one
+    // minified bundle (src/dist/xopat-core.min.js), emitted once on the first
+    // core JS group requested; per-group CSS is preserved and `env` goes
+    // per-file. Falls back to per-file dev serving when the bundle isn't built.
+    $production = !empty($CORE["client"]["production"]);
+    if ($production && in_array($type, ["loader", "deps", "app"], true)
+        && file_exists(VIEWER_SOURCES_ABS_ROOT . "dist/xopat-core.min.js")) {
+        if (isset($CORE["css"]["src"][$type])) print_css_single($CORE["css"]["src"][$type], PROJECT_SOURCES);
+        if (!$bundleEmitted) {
+            $bundleEmitted = true;
+            $version = VERSION;
+            echo "    <script src=\"" . PROJECT_SOURCES . "dist/xopat-core.min.js?v=$version\"></script>\n";
+        }
+        return;
+    }
+
     if (isset($CORE["css"]["src"][$type])) print_css_single($CORE["css"]["src"][$type], PROJECT_SOURCES);
     if (isset($CORE["js"]["src"][$type])) print_js_single($CORE["js"]["src"][$type], PROJECT_SOURCES);
 }
 
 function require_ui() {
     global $CORE;
+    // In production, serve the prebuilt single UI bundle (ui/index.min.js),
+    // preserving any UI CSS. Falls back to the ESM index.js otherwise.
+    if (!empty($CORE["client"]["production"]) && file_exists(ABSPATH . "ui/index.min.js")) {
+        if (isset($CORE["css"]["ui"])) print_css($CORE["css"]["ui"], UI_SOURCES);
+        $version = VERSION;
+        echo "    <script src=\"" . UI_SOURCES . "index.min.js?v=$version\"></script>\n";
+        return;
+    }
     print_js($CORE["js"]["ui"], UI_SOURCES);
 }
 

--- a/server/php/inc/modules.php
+++ b/server/php/inc/modules.php
@@ -119,6 +119,73 @@ function expand_include_globs($basePath, $includes) {
     return $expanded;
 }
 
+/** True when the deployment client config requests production (minified) serving. */
+function xopat_is_production(): bool {
+    global $CORE;
+    return is_array($CORE) && !empty($CORE['client']['production']);
+}
+
+/**
+ * Classify a single includes[] entry: "classic" (local .js → index.min.js),
+ * "module" (.mjs → index.min.mjs) or "separate" (remote / .min.js / object-form
+ * / `bundle:false`). Mirrors classifyIncludeKind in the Node template.
+ */
+function xopat_include_kind($entry): string {
+    if (is_string($entry)) {
+        if (preg_match('#^https?://#', $entry)) return 'separate';
+        if (str_ends_with($entry, '.mjs')) return 'module';
+        if (str_ends_with($entry, '.min.js')) return 'separate';
+        if (str_ends_with($entry, '.js')) return 'classic';
+        return 'separate';
+    }
+    return 'separate';
+}
+
+/**
+ * Compute the optional production `prodIncludes` overlay, leaving canonical
+ * `includes` untouched. Mirrors buildProdIncludes in the Node template: classic
+ * `.js` collapse into index.min.js, `.mjs` modules into index.min.mjs, each used
+ * only if its artifact exists; "separate" entries stay in place.
+ */
+function xopat_build_prod_includes($full_path, &$data, $production) {
+    if (!$production || !is_array($data)) return;
+    if (!isset($data['includes']) || !is_array($data['includes']) || count($data['includes']) === 0) return;
+    $includes = array_values($data['includes']);
+
+    $wsEntry = $includes[0];
+    if ($wsEntry === 'index.workspace.js') {
+        if (!file_exists($full_path . 'index.workspace.min.js')) return;
+        $data['prodIncludes'] = array_merge(['index.workspace.min.js'], array_slice($includes, 1));
+        return;
+    }
+    // .mjs workspace bundles / `main` entries can't be a classic min file.
+    if (is_string($wsEntry) && str_starts_with($wsEntry, 'index.workspace.')) return;
+
+    $hasClassic = false; $hasModule = false;
+    foreach ($includes as $e) {
+        $k = xopat_include_kind($e);
+        if ($k === 'classic') $hasClassic = true;
+        else if ($k === 'module') $hasModule = true;
+    }
+    $classicOk = $hasClassic && file_exists($full_path . 'index.min.js');
+    $moduleOk  = $hasModule  && file_exists($full_path . 'index.min.mjs');
+    if (!$classicOk && !$moduleOk) return;
+
+    $result = [];
+    $classicPlaced = false; $modulePlaced = false;
+    foreach ($includes as $e) {
+        $k = xopat_include_kind($e);
+        if ($k === 'classic' && $classicOk) {
+            if (!$classicPlaced) { $result[] = 'index.min.js'; $classicPlaced = true; }
+        } else if ($k === 'module' && $moduleOk) {
+            if (!$modulePlaced) { $result[] = 'index.min.mjs'; $modulePlaced = true; }
+        } else {
+            $result[] = $e;
+        }
+    }
+    $data['prodIncludes'] = $result;
+}
+
 $XOPAT_MODULE_SELECTION_MODE = xopat_resolve_plugin_selection_mode();
 
 foreach (array_diff(scandir(ABS_MODULES), array('..', '.')) as $_=>$dir) {
@@ -252,6 +319,9 @@ foreach (array_diff(scandir(ABS_MODULES), array('..', '.')) as $_=>$dir) {
             $configSatisfied = $XOPAT_MODULE_SELECTION_MODE !== 'available'
                 || xopat_required_config_satisfied($data["requiredConfig"] ?? null, $envBlock, $secBlock);
             if ($enabledNotFalse && $configSatisfied) {
+                // Precompute the production single-file overlay (leaves
+                // `includes` canonical); see xopat_build_prod_includes.
+                xopat_build_prod_includes($full_path, $data, xopat_is_production());
                 $MODULES[$data["id"]] = $data;
             }
         }
@@ -341,12 +411,13 @@ function printDependencies($directory, $item, $production) {
         echo "<link rel=\"stylesheet\" href=\"{$item["styleSheet"]}?v=$version\" type='text/css'>\n";
     }
 
-    if ($production && file_exists("$directory{$item["directory"]}/index.min.js")) {
-        echo "    <script src=\"$directory{$item["directory"]}/index.min.js?v=$version\"></script>\n";
-        return;
-    }
+    // In production the item may carry a precomputed `prodIncludes` overlay
+    // (foldable files collapsed into index.min.js / index.workspace.min.js,
+    // non-foldable entries kept in place). Fall back to canonical `includes`.
+    $includesList = ($production && isset($item["prodIncludes"]) && is_array($item["prodIncludes"]))
+        ? $item["prodIncludes"] : $item["includes"];
 
-    foreach ($item["includes"] as $__ => $file) {
+    foreach ($includesList as $__ => $file) {
         if (is_string($file)) {
             $path = "$directory{$item["directory"]}/$file?v=$version";
             if (str_ends_with($file, '.mjs')) {

--- a/server/php/inc/modules.php
+++ b/server/php/inc/modules.php
@@ -119,11 +119,8 @@ function expand_include_globs($basePath, $includes) {
     return $expanded;
 }
 
-/** True when the deployment client config requests production (minified) serving. */
-function xopat_is_production(): bool {
-    global $CORE;
-    return is_array($CORE) && !empty($CORE['client']['production']);
-}
+// xopat_is_production() is defined in core.php (loaded first) with a robust
+// FILTER_VALIDATE_BOOLEAN check, so "false"/"0"/"" strings are handled.
 
 /**
  * Classify a single includes[] entry: "classic" (local .js → index.min.js),

--- a/server/php/inc/plugins.php
+++ b/server/php/inc/plugins.php
@@ -188,6 +188,9 @@ foreach (array_diff(scandir(ABS_PLUGINS), array('..', '.')) as $_=>$dir) {
                 }
 
                 if ($shouldInclude) {
+                    // Precompute the production single-file overlay (leaves
+                    // `includes` canonical); see xopat_build_prod_includes.
+                    xopat_build_prod_includes($dir_path, $data, xopat_is_production());
                     $PLUGINS[$data["id"]] = $data;
                 }
             }

--- a/server/static/build.grunt.js
+++ b/server/static/build.grunt.js
@@ -83,11 +83,15 @@ ${core.requireCore("app")}`;
 
                 case "modules":
                     grunt.log.write(' modules');
-                    return core.requireModules();
+                    // Honor production so static exports get one min file per
+                    // item too. requireCore/requireUI read production internally.
+                    // NOTE: run `grunt minify` before the static build so the
+                    // min artifacts exist; missing ones degrade to raw per-file.
+                    return core.requireModules(core.CORE?.client?.production);
 
                 case "plugins":
                     grunt.log.write(' plugins');
-                    return core.requirePlugins();
+                    return core.requirePlugins(core.CORE?.client?.production);
 
                 default:
                     grunt.log.write(` [unknown template key ${p1}]`);

--- a/server/templates/javascript/core.js
+++ b/server/templates/javascript/core.js
@@ -139,10 +139,40 @@ module.exports.getCore = function(absPath, projectRoot, fileExists, readFile, re
         },
 
         requireCore(type) {
+            // In production, serve the whole core JS (loader + deps + app groups)
+            // as one minified bundle (src/dist/xopat-core.min.js, produced by
+            // buildCore). Emitted once, on the first core JS group requested;
+            // per-group CSS is preserved. `env` (CSS) always goes per-file. Falls
+            // back to per-file dev serving when the bundle isn't built.
+            const production = parseBool(this.CORE?.client?.production) === true;
+            if (production && (type === "loader" || type === "deps" || type === "app")
+                && fileExists(this.VIEWER_SOURCES_ABS_ROOT + "dist/xopat-core.min.js")) {
+                let result = "";
+                if (this.CORE["css"] && this.CORE["css"]["src"] && this.CORE["css"]["src"][type] !== undefined) {
+                    result += this.printCss(this.CORE["css"]["src"][type], this.PROJECT_SOURCES);
+                }
+                if (!this._coreBundleEmitted) {
+                    this._coreBundleEmitted = true;
+                    result += `    <script src="${this.PROJECT_SOURCES}dist/xopat-core.min.js?v=${this.VERSION}"></script>\n`;
+                }
+                return result;
+            }
             return this._requireNested("src", type, this.PROJECT_SOURCES);
         },
 
         requireUI: function () {
+            // In production, serve the prebuilt single UI bundle (ui/index.min.js,
+            // produced by `grunt minify`), preserving any UI CSS. Falls back to
+            // the ESM index.js in dev / when the min bundle isn't built.
+            const production = parseBool(this.CORE?.client?.production) === true;
+            if (production && fileExists(this.ABS_UI + "index.min.js")) {
+                let result = "";
+                if (this.CORE["css"] && this.CORE["css"]["ui"] !== undefined) {
+                    result += this.printCss(this.CORE["css"]["ui"], this.UI_SOURCES);
+                }
+                result += `    <script src="${this.UI_SOURCES}index.min.js?v=${this.VERSION}"></script>\n`;
+                return result;
+            }
             return this._require("ui", this.UI_SOURCES);
         },
 

--- a/server/templates/javascript/core.js
+++ b/server/templates/javascript/core.js
@@ -370,6 +370,13 @@ module.exports.getCore = function(absPath, projectRoot, fileExists, readFile, re
     }
     CORE["client"] = C;
 
+    // Coerce the production flag to a strict boolean at the client-flatten
+    // boundary, so every downstream check is correct even if it arrived as a
+    // string (e.g. "false" from an env var, which is truthy in JS).
+    if (C && typeof C === "object") {
+        CORE["client"]["production"] = parseBool(CORE["client"]["production"]) === true;
+    }
+
     /*
      * Auto detect path and domain if null
      */

--- a/server/templates/javascript/modules.js
+++ b/server/templates/javascript/modules.js
@@ -255,7 +255,7 @@ module.exports.loadModules = function(core, fileExists, readFile, i18n) {
         // (foldable files collapsed into index.min.js / index.workspace.min.js,
         // non-foldable entries kept in place). Fall back to the canonical
         // `includes` in dev or when no min artifact exists. See buildProdIncludes.
-        const includesList = (production && Array.isArray(item["prodIncludes"]))
+        const includesList = ((core.parseBool(production) === true) && Array.isArray(item["prodIncludes"]))
             ? item["prodIncludes"] : item["includes"];
 
         for (let file of includesList) {

--- a/server/templates/javascript/modules.js
+++ b/server/templates/javascript/modules.js
@@ -3,7 +3,8 @@ const {
     safeScanDir,
     expandIncludeGlobs,
     resolvePluginSelectionMode,
-    requiredConfigSatisfied
+    requiredConfigSatisfied,
+    buildProdIncludes
 } = require("./utils");
 
 module.exports.loadModules = function(core, fileExists, readFile, i18n) {
@@ -131,6 +132,10 @@ module.exports.loadModules = function(core, fileExists, readFile, i18n) {
                 const configSatisfied = pluginSelectionMode !== "available"
                     || requiredConfigSatisfied(data["requiredConfig"], envBlock, secBlock);
                 if (enabledNotFalse && configSatisfied) {
+                    // Precompute the production single-file overlay (leaves
+                    // `includes` canonical); consumed by printDependencies and
+                    // the client dynamic loader alike.
+                    buildProdIncludes(fullPath, data, core.CORE?.client?.production, fileExists);
                     MODULES[data["id"]] = data;
                 }
             }
@@ -246,15 +251,14 @@ module.exports.loadModules = function(core, fileExists, readFile, i18n) {
             result = `<link rel="stylesheet" href="${item["styleSheet"]}?v=${version}" type='text/css'>\n`;
         }
 
-        if (production && fileExists(`${directory}${item["directory"]}/index.min.js`)) {
-            return result + `    <script src="${directory}${item["directory"]}/index.min.js?v=${version}"></script>\n`;
-        }
+        // In production the item may carry a precomputed `prodIncludes` overlay
+        // (foldable files collapsed into index.min.js / index.workspace.min.js,
+        // non-foldable entries kept in place). Fall back to the canonical
+        // `includes` in dev or when no min artifact exists. See buildProdIncludes.
+        const includesList = (production && Array.isArray(item["prodIncludes"]))
+            ? item["prodIncludes"] : item["includes"];
 
-        if (production && fileExists(`${directory}${item["directory"]}/index.workspace.min.js`)) {
-            return result + `    <script src="${directory}${item["directory"]}/index.workspace.min.js?v=${version}"></script>\n`;
-        }
-
-        for (let file of item["includes"]) {
+        for (let file of includesList) {
             if (isType(file, "string")) {
                 result += file.endsWith(".mjs") ?
                     `    <script src="${directory}${item["directory"]}/${file}?v=${version}" type="module"></script>\n` :

--- a/server/templates/javascript/modules.js
+++ b/server/templates/javascript/modules.js
@@ -135,7 +135,7 @@ module.exports.loadModules = function(core, fileExists, readFile, i18n) {
                     // Precompute the production single-file overlay (leaves
                     // `includes` canonical); consumed by printDependencies and
                     // the client dynamic loader alike.
-                    buildProdIncludes(fullPath, data, core.CORE?.client?.production, fileExists);
+                    buildProdIncludes(fullPath, data, core.parseBool(core.CORE?.client?.production) === true, fileExists);
                     MODULES[data["id"]] = data;
                 }
             }

--- a/server/templates/javascript/plugins.js
+++ b/server/templates/javascript/plugins.js
@@ -183,7 +183,7 @@ module.exports.loadPlugins = function(core, fileExists, readFile, i18n) {
                 if (shouldInclude) {
                     // Precompute the production single-file overlay (leaves
                     // `includes` canonical); see buildProdIncludes.
-                    buildProdIncludes(fullPath, data, core.CORE?.client?.production, fileExists);
+                    buildProdIncludes(fullPath, data, core.parseBool(core.CORE?.client?.production) === true, fileExists);
                     PLUGINS[data["id"]] = data;
                 }
             }

--- a/server/templates/javascript/plugins.js
+++ b/server/templates/javascript/plugins.js
@@ -4,7 +4,8 @@ const {
     safeScanDir,
     expandIncludeGlobs,
     resolvePluginSelectionMode,
-    requiredConfigSatisfied
+    requiredConfigSatisfied,
+    buildProdIncludes
 } = require("./utils");
 
 module.exports.loadPlugins = function(core, fileExists, readFile, i18n) {
@@ -180,6 +181,9 @@ module.exports.loadPlugins = function(core, fileExists, readFile, i18n) {
                 }
 
                 if (shouldInclude) {
+                    // Precompute the production single-file overlay (leaves
+                    // `includes` canonical); see buildProdIncludes.
+                    buildProdIncludes(fullPath, data, core.CORE?.client?.production, fileExists);
                     PLUGINS[data["id"]] = data;
                 }
             }

--- a/server/templates/javascript/utils.js
+++ b/server/templates/javascript/utils.js
@@ -103,6 +103,105 @@ module.exports.requiredConfigSatisfied = function (paths, ...records) {
 };
 
 /**
+ * Classify a single `includes[]` entry into how it participates in production
+ * bundling. The rule is derived purely from the entry's own shape — no per-file
+ * authoring is needed — plus an explicit `bundle: false` opt-out for object-form
+ * entries.
+ *
+ *   - `"classic"`: a plain, local, classic `.js` string (not already minified).
+ *      Concatenated into the per-item `index.min.js` (classic IIFE bundle).
+ *   - `"module"`: a local `.mjs` ES module. esbuild-bundled + minified into the
+ *      per-item `index.min.mjs` (served as `type="module"`).
+ *   - `"separate"`: loaded as its own file, never bundled — remote `http(s)`
+ *      URLs, already-`.min.js` vendored bundles, and any object-form include
+ *      (SRI/attributes, or `{ "src": "x.worker.js", "bundle": false }` — the
+ *      explicit marker for a local file that must stay standalone, e.g. a Web
+ *      Worker source that only looks foldable by its `.js` suffix).
+ *
+ * Reused by the Grunt build tasks so each "kind" has exactly one definition
+ * across build and serve.
+ * @param {string|object} entry
+ * @returns {"classic"|"module"|"separate"}
+ */
+module.exports.classifyIncludeKind = function (entry) {
+    if (typeof entry === "string") {
+        if (/^https?:\/\//.test(entry)) return "separate";
+        if (entry.endsWith(".mjs")) return "module";
+        if (entry.endsWith(".min.js")) return "separate";
+        if (entry.endsWith(".js")) return "classic";
+        return "separate";
+    }
+    // Object-form includes are never bundled: they either carry SRI/attributes
+    // or are explicitly marked `bundle: false`.
+    return "separate";
+};
+
+/** Back-compat convenience: the classic-concat predicate used by `prepMinify`. */
+module.exports.classifyIncludeFoldable = function (entry) {
+    return module.exports.classifyIncludeKind(entry) === "classic";
+};
+
+/**
+ * Compute the optional per-item `prodIncludes` list used in production. Leaves
+ * the canonical `includes[]` untouched; the loader (server-print AND the client
+ * dynamic loader) iterates `prodIncludes` when present, else `includes`.
+ *
+ * Foldable includes collapse into a single `index.min.js` (non-workspace) or the
+ * already-minified `index.workspace.min.js` (workspace items) placed at the
+ * position of the first foldable entry; non-foldable entries keep loading in
+ * their original positions. If nothing is foldable, or the expected `.min`
+ * artifact does not exist yet, `prodIncludes` is left unset (graceful fallback).
+ *
+ * @param {string} fullPath absolute item directory, ending with a slash
+ * @param {object} data parsed item metadata (mutated: sets data.prodIncludes)
+ * @param {boolean} production
+ * @param {function(string):boolean} fileExists
+ */
+module.exports.buildProdIncludes = function (fullPath, data, production, fileExists) {
+    if (!production || !data) return;
+    const includes = data["includes"];
+    if (!Array.isArray(includes) || includes.length === 0) return;
+
+    const kindOf = module.exports.classifyIncludeKind;
+
+    // Workspace item: its bundle (already esbuild-minified) is the copied
+    // index.workspace.min.js. The workspace entry is always includes[0].
+    const wsEntry = includes[0];
+    if (wsEntry === "index.workspace.js") {
+        if (!fileExists(fullPath + "index.workspace.min.js")) return;
+        // Fold nothing else; keep any extra includes as their own files.
+        data["prodIncludes"] = ["index.workspace.min.js", ...includes.slice(1)];
+        return;
+    }
+    // .mjs workspace bundles / `main` entries are served as-is.
+    if (typeof wsEntry === "string" && wsEntry.startsWith("index.workspace.")) return;
+
+    // Two independent single-file bundles: classic `.js` → index.min.js (IIFE),
+    // `.mjs` modules → index.min.mjs (ESM). Either may be present; each is used
+    // only if it has ≥1 member and its artifact exists (else those entries fall
+    // back to raw per-file serving). "separate" entries always stay in place.
+    const hasClassic = includes.some(e => kindOf(e) === "classic");
+    const hasModule  = includes.some(e => kindOf(e) === "module");
+    const classicOk = hasClassic && fileExists(fullPath + "index.min.js");
+    const moduleOk  = hasModule  && fileExists(fullPath + "index.min.mjs");
+    if (!classicOk && !moduleOk) return;
+
+    const result = [];
+    let classicPlaced = false, modulePlaced = false;
+    for (const entry of includes) {
+        const kind = kindOf(entry);
+        if (kind === "classic" && classicOk) {
+            if (!classicPlaced) { result.push("index.min.js"); classicPlaced = true; }
+        } else if (kind === "module" && moduleOk) {
+            if (!modulePlaced) { result.push("index.min.mjs"); modulePlaced = true; }
+        } else {
+            result.push(entry); // separate, or a kind whose bundle wasn't built
+        }
+    }
+    data["prodIncludes"] = result;
+};
+
+/**
  * Expands glob patterns within an array of includes.
  * @param {string} basePath The absolute path to the directory.
  * @param {Array} includes The includes array from config.

--- a/server/utils/mixins/build-logic.js
+++ b/server/utils/mixins/build-logic.js
@@ -216,6 +216,19 @@ const BuildLogic = {
                 `--footer:js=window.${namespace}['${cleanId}'] = window.${namespace}['${cleanId}'] || globalThis.__temp_bundle_export; delete globalThis.__temp_bundle_export;`
             );
             await spawnAsync("npx", buildArgs);
+
+            // Production single-file artifact. Only fabricated here, in the
+            // esbuild `--minify` branch, where we KNOW the output is minified —
+            // so `index.workspace.min.js` (what printDependencies/prodIncludes
+            // look for in production) is a faithful copy. Custom `scripts.*`
+            // builds and prebuilt-shipped bundles are NOT copied, since we can't
+            // assume they are minified; such items must ship their own
+            // index.workspace.min.js or they fall back to raw serving. (.mjs
+            // workspace bundles are served as-is and need no classic min copy.)
+            if (fs.existsSync(outFile)) {
+                fs.copyFileSync(outFile, path.join(itemDirectory, "index.workspace.min.js"));
+                logger.log(`${logPrefix} wrote index.workspace.min.js`);
+            }
         } else {
             logger.log(`${logPrefix} No scripts or "buildEntry" entry point found. Skipping JS build.`);
         }
@@ -226,17 +239,6 @@ const BuildLogic = {
         // 3. Handle asset copying if defined
         if (packageData.copy) {
             executeCopy(itemDirectory, packageData.copy, logger, logPrefix);
-        }
-
-        // 4. Production single-file artifact. The workspace bundle is already a
-        // minified IIFE (esbuild `--minify` above, or a prebuilt shipped bundle),
-        // so `index.workspace.min.js` — the file printDependencies/prodIncludes
-        // look for in production — is just a copy. (.mjs workspace bundles are
-        // served as-is and need no classic min variant.)
-        const wsBundle = path.join(itemDirectory, "index.workspace.js");
-        if (fs.existsSync(wsBundle)) {
-            fs.copyFileSync(wsBundle, path.join(itemDirectory, "index.workspace.min.js"));
-            logger?.log?.(`${logPrefix} wrote index.workspace.min.js`);
         }
     },
 
@@ -288,6 +290,12 @@ const BuildLogic = {
     async buildItemModuleBundle(itemDirectory, moduleIncludes, logger) {
         if (!Array.isArray(moduleIncludes) || moduleIncludes.length === 0) return;
         const outFile = path.join(itemDirectory, "index.min.mjs");
+        // Remove any prior artifact up front, so a failed (re)build leaves it
+        // ABSENT — production then falls back to raw `.mjs` per file instead of
+        // silently serving a stale bundle (matches the documented behavior).
+        for (const stale of [outFile, outFile + ".map"]) {
+            if (fs.existsSync(stale)) fs.unlinkSync(stale);
+        }
         let entry, tmp = null;
         if (moduleIncludes.length === 1) {
             entry = path.join(itemDirectory, moduleIncludes[0]);
@@ -358,6 +366,15 @@ const BuildLogic = {
      */
     async buildCoreBundle(logger) {
         const CommentJSON = require("comment-json");
+        const distDir = path.join("src", "dist");
+        const outFile = path.join(distDir, "xopat-core.min.js");
+        // Remove any prior bundle up front, so every early-exit / failure path
+        // below leaves it ABSENT — production then falls back to per-file core
+        // serving instead of shipping a stale bundle.
+        for (const stale of [outFile, outFile + ".map"]) {
+            if (fs.existsSync(stale)) fs.unlinkSync(stale);
+        }
+
         const configPath = path.join("src", "config.json");
         if (!fs.existsSync(configPath)) return;
         const config = CommentJSON.parse(fs.readFileSync(configPath, "utf8"), null, true);
@@ -377,14 +394,13 @@ const BuildLogic = {
             combined += `\n;/* ${rel} */\n${fs.readFileSync(p, "utf8")}\n`;
         }
 
-        const distDir = path.join("src", "dist");
         if (!fs.existsSync(distDir)) fs.mkdirSync(distDir, { recursive: true });
         const tmp = path.join(distDir, ".xopat-core.bundle.js");
         fs.writeFileSync(tmp, combined);
         try {
             await spawnAsync("npx", [
                 "esbuild", tmp, "--minify", "--target=es2019",
-                `--outfile=${path.join(distDir, "xopat-core.min.js")}`
+                `--outfile=${outFile}`
             ]);
             logger.log("[build] wrote src/dist/xopat-core.min.js");
         } finally {

--- a/server/utils/mixins/build-logic.js
+++ b/server/utils/mixins/build-logic.js
@@ -227,6 +227,17 @@ const BuildLogic = {
         if (packageData.copy) {
             executeCopy(itemDirectory, packageData.copy, logger, logPrefix);
         }
+
+        // 4. Production single-file artifact. The workspace bundle is already a
+        // minified IIFE (esbuild `--minify` above, or a prebuilt shipped bundle),
+        // so `index.workspace.min.js` — the file printDependencies/prodIncludes
+        // look for in production — is just a copy. (.mjs workspace bundles are
+        // served as-is and need no classic min variant.)
+        const wsBundle = path.join(itemDirectory, "index.workspace.js");
+        if (fs.existsSync(wsBundle)) {
+            fs.copyFileSync(wsBundle, path.join(itemDirectory, "index.workspace.min.js"));
+            logger?.log?.(`${logPrefix} wrote index.workspace.min.js`);
+        }
     },
 
     /**
@@ -235,11 +246,13 @@ const BuildLogic = {
     async cleanWorkspaceItem(itemDirectory, packageData, logger) {
         const logPrefix = `[clean] ${packageData.name || itemDirectory}:`;
 
-        // Remove default build artifact
-        const defaultBuild = path.join(itemDirectory, "index.workspace.js");
-        if (fs.existsSync(defaultBuild)) {
-            logger.log(`${logPrefix} removing ${defaultBuild}`);
-            fs.unlinkSync(defaultBuild);
+        // Remove default build artifact + its production min copy
+        for (const artifact of ["index.workspace.js", "index.workspace.min.js"]) {
+            const p = path.join(itemDirectory, artifact);
+            if (fs.existsSync(p)) {
+                logger.log(`${logPrefix} removing ${p}`);
+                fs.unlinkSync(p);
+            }
         }
 
         const serverOutDir = path.join(itemDirectory, ".server-dist");
@@ -260,6 +273,44 @@ const BuildLogic = {
         }
     },
 
+    /**
+     * Bundle a NON-workspace item's `.mjs` includes into a single minified ESM
+     * file `index.min.mjs` (served as `type="module"` in production). A single
+     * `.mjs` include is bundled directly; multiple independent module scripts
+     * are sequenced through a generated wrapper that imports each in order, so
+     * side-effect order matches loading them as separate module scripts. Item
+     * globals (USER_INTERFACE, VIEWER_MANAGER, …) are left as global refs by
+     * esbuild; only real `import`s are inlined. On failure the artifact is
+     * absent and serving falls back to raw `.mjs` per file.
+     * @param {string} itemDirectory
+     * @param {string[]} moduleIncludes ordered relative `.mjs` paths to bundle
+     */
+    async buildItemModuleBundle(itemDirectory, moduleIncludes, logger) {
+        if (!Array.isArray(moduleIncludes) || moduleIncludes.length === 0) return;
+        const outFile = path.join(itemDirectory, "index.min.mjs");
+        let entry, tmp = null;
+        if (moduleIncludes.length === 1) {
+            entry = path.join(itemDirectory, moduleIncludes[0]);
+        } else {
+            tmp = path.join(itemDirectory, ".xopat-mjs-entry.mjs");
+            fs.writeFileSync(tmp, moduleIncludes.map(f => `import ${JSON.stringify("./" + f)};`).join("\n") + "\n");
+            entry = tmp;
+        }
+        try {
+            // No --target downlevel: these are served natively as ES modules
+            // (type="module"), and the raw `.mjs` already run untransformed, so
+            // downleveling (which e.g. blanks out `import.meta.url`) would change
+            // behavior. esbuild defaults to esnext, preserving the source syntax.
+            await spawnAsync("npx", [
+                "esbuild", entry, "--bundle", "--format=esm", "--minify",
+                "--sourcemap", `--outfile=${outFile}`
+            ]);
+            logger.log(`[build] wrote ${outFile}`);
+        } finally {
+            if (tmp && fs.existsSync(tmp)) fs.unlinkSync(tmp);
+        }
+    },
+
     async buildUI(logger) {
         logger.log("[build] Compiling UI (ESM)...");
         return spawnAsync("npx", [
@@ -274,7 +325,7 @@ const BuildLogic = {
 
     async buildCore(logger) {
         logger.log("[build] Compiling Core (TypeScript)...");
-        return spawnAsync("npx", [
+        await spawnAsync("npx", [
             "esbuild",
             "src/**/*.ts",
             "--bundle",
@@ -283,6 +334,62 @@ const BuildLogic = {
             "--outdir=src/dist",
             "--sourcemap"
         ]);
+
+        // Production single-file core. The per-file dev build above stays the
+        // dev serving path; here we additionally concatenate the ordered core
+        // scripts (from config.json `js.src`) into one minified bundle served by
+        // requireCore in production. If this fails the artifact is simply absent
+        // and serving falls back per-file, so it never blocks a build.
+        try {
+            await BuildLogic.buildCoreBundle(logger);
+        } catch (e) {
+            logger.error ? logger.error(`[build] core bundle skipped: ${e && e.message || e}`)
+                : logger.log(`[build] core bundle skipped: ${e && e.message || e}`);
+        }
+    },
+
+    /**
+     * Concatenate the ordered core JS (config.json `js.src`: loader → deps →
+     * app, dist IIFE outputs + the hand-authored classic scripts) in exact load
+     * order and minify to src/dist/xopat-core.min.js. Concatenation (not module
+     * bundling) preserves the classic multi-script execution + global-assignment
+     * semantics; esbuild `--minify` will fail loudly on a genuine duplicate
+     * top-level declaration rather than silently miscompile.
+     */
+    async buildCoreBundle(logger) {
+        const CommentJSON = require("comment-json");
+        const configPath = path.join("src", "config.json");
+        if (!fs.existsSync(configPath)) return;
+        const config = CommentJSON.parse(fs.readFileSync(configPath, "utf8"), null, true);
+        const src = (config && config.js && config.js.src) || {};
+        const ordered = [...(src.loader || []), ...(src.deps || []), ...(src.app || [])];
+        if (!ordered.length) { logger.log("[build] core bundle: empty js.src, skipped"); return; }
+
+        let combined = "";
+        for (const rel of ordered) {
+            const p = path.join("src", rel);
+            if (!fs.existsSync(p)) {
+                logger.log(`[build] core bundle: missing ${rel} — skipping bundle`);
+                return; // never emit a partial bundle
+            }
+            // Leading `;` + newline guards against ASI hazards when a file that
+            // ends without a semicolon is followed by one starting with ( or [.
+            combined += `\n;/* ${rel} */\n${fs.readFileSync(p, "utf8")}\n`;
+        }
+
+        const distDir = path.join("src", "dist");
+        if (!fs.existsSync(distDir)) fs.mkdirSync(distDir, { recursive: true });
+        const tmp = path.join(distDir, ".xopat-core.bundle.js");
+        fs.writeFileSync(tmp, combined);
+        try {
+            await spawnAsync("npx", [
+                "esbuild", tmp, "--minify", "--target=es2019",
+                `--outfile=${path.join(distDir, "xopat-core.min.js")}`
+            ]);
+            logger.log("[build] wrote src/dist/xopat-core.min.js");
+        } finally {
+            if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+        }
     },
 
     spawnAsync,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -581,10 +581,16 @@ export function initXOpatLoader(ENV: XOpatCoreConfig, PLUGINS: Record<string, XO
     }
 
     function chainLoad(id: string, sources: XOpatElementRecord, index: number, onSuccess: () => void, folder: string = PLUGINS_FOLDER) {
-        if (index >= sources.includes.length) {
+        // In production the server may attach a `prodIncludes` overlay: foldable
+        // files collapsed into a single index.min.js, non-foldable entries kept
+        // in place. Fall back to the canonical `includes` in dev / when no min
+        // artifact exists. Same entry shapes, so the per-entry handling below is
+        // reused unchanged. See server/templates/javascript/utils.js.
+        const list = sources.prodIncludes ?? sources.includes;
+        if (index >= list.length) {
             onSuccess();
         } else {
-            let toLoad = sources.includes[index],
+            let toLoad = list[index],
                 properties: Partial<ScriptProperties> = {};
             if (typeof toLoad === "string") {
                 properties.src = `${folder}${sources.directory}/${toLoad}?v=${version}`;

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -264,6 +264,13 @@ type XOpatElementItem = {
     directory: string;
     /** Files to include (JS/MJS) */
     includes: Array<string | Record<string, any>>;
+    /**
+     * Production-only overlay computed server-side (see buildProdIncludes):
+     * foldable includes collapsed into a single minified bundle, non-foldable
+     * entries kept in place. The loader iterates this when present, else
+     * `includes`. Absent in dev or when no min artifact exists.
+     */
+    prodIncludes?: Array<string | Record<string, any>>;
     /** If true, the element is always loaded on boot */
     permaLoad: boolean;
     /** Module IDs to require for a plugin */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production builds now generate and serve optimized core, UI, plugin, and module bundles for faster loading.
  * Added a production build command for creating minified assets.
  * Demo embeds now display a loading indicator and fade in once ready.

* **Bug Fixes**
  * Production serving falls back to original files when optimized bundles are unavailable.
  * Worker and other standalone resources remain separately loadable.

* **Documentation**
  * Clarified bundling behavior and opt-out options for modules and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->